### PR TITLE
Compare Authorization header with case folded

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -56,7 +56,7 @@ func SignedInID(c *macaron.Context, sess session.Store) string {
 		if len(auHead) > 0 {
 
 			auths := strings.Fields(auHead)
-			if len(auths) == 2 && auths[0] == "token" {
+			if len(auths) == 2 && strings.EqualFold(auths[0], "token") {
 				tokenSHA = auths[1]
 			}
 		}


### PR DESCRIPTION
While it is not dictated by any spec, the authentication type name is usually capitalized:
http://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
Which is what an unprepared user would try to do.
Just accepting both capitalized and all-lowers should do the trick.